### PR TITLE
Add opt-in settle delay before screenshot verification

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -159,6 +159,18 @@ module Deliver
 
       UI.verbose('Uploading jobs are completed')
 
+      # Give App Store Connect time to make freshly-uploaded screenshots readable
+      # before we verify. Without this, ASC's eventual-consistency lag makes the
+      # verification (wait_for_complete + verify_local_screenshots_are_uploaded)
+      # falsely report just-uploaded screenshots as "missing", triggering a retry
+      # that re-uploads WITHOUT deleting and leaves duplicate screenshots live.
+      # Opt-in via env var; defaults to 0 to preserve upstream behavior.
+      settle_seconds = ENV['DELIVER_SCREENSHOT_SETTLE_SECONDS'].to_i
+      if settle_seconds.positive?
+        UI.message("Waiting #{settle_seconds}s for screenshots to settle on App Store Connect before verifying...")
+        sleep(settle_seconds)
+      end
+
       Helper.show_loading_indicator("Waiting for all the screenshots to finish being processed...")
       states = wait_for_complete(iterator, timeout_seconds)
       Helper.hide_loading_indicator


### PR DESCRIPTION
## Problem

When uploading screenshots, `deliver` polls App Store Connect immediately after upload to verify they landed. ASC has eventual-consistency lag, so the just-uploaded screenshots aren't yet visible (~6–12s). `deliver` then falsely reports them `missing on App Store Connect`, enters its retry loop (`Tries remaining: N`), and **re-uploads without deleting first** — leaving duplicate screenshots live on the listing.

This bit our mass app submission: nearly every app ended up with two copies of each screenshot.

## Change

Adds an opt-in settle delay in `deliver/lib/deliver/upload_screenshots.rb`, right after the upload worker finishes and **before** `wait_for_complete`:

```ruby
settle_seconds = ENV['DELIVER_SCREENSHOT_SETTLE_SECONDS'].to_i
if settle_seconds.positive?
  UI.message("Waiting #{settle_seconds}s for screenshots to settle on App Store Connect before verifying...")
  sleep(settle_seconds)
end
```

Gated by `DELIVER_SCREENSHOT_SETTLE_SECONDS`, **default `0`** — so behavior is unchanged unless a consumer opts in. With it set (we use 45s in CI), the verification sees the uploaded screenshots on the first pass, so the false-`missing` → re-upload retry never fires and no duplicates are created.

This keeps the proven legacy upload path; it does not touch the beta `sync_screenshots` path (which crashes on the same lag).

## Branch note

`screenshot-settle-delay` was branched off the current tip of `brick/ipad-gen-2-screenshot-name-fix` (`c9f47f5`), so it includes the existing iPad-naming fix plus this single addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)