### PR TITLE
Widen excon dependency bound to allow excon 1.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       commander (~> 4.6)
       dotenv (>= 2.1.1, < 3.0.0)
       emoji_regex (>= 0.1, < 4.0)
-      excon (>= 0.71.0, < 1.0.0)
+      excon (>= 0.71.0, < 2.0.0)
       faraday (~> 1.0)
       faraday-cookie_jar (~> 0.0.6)
       faraday_middleware (~> 1.0)
@@ -119,7 +119,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     emoji_regex (3.2.3)
-    excon (0.94.0)
+    excon (1.6.0)
+      logger
     fakefs (1.2.3)
     faraday (1.10.5)
       faraday-em_http (~> 1.0)
@@ -216,6 +217,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    logger (1.7.0)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -91,7 +91,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('babosa', '>= 1.0.3', "< 2.0.0") # library for creating human-friendly identifiers, aka "slugs"
   spec.add_dependency('colored') # colored terminal output
   spec.add_dependency('commander', '~> 4.6') # CLI parser
-  spec.add_dependency('excon', '>= 0.71.0', '< 1.0.0') # Great HTTP Client
+  spec.add_dependency('excon', '>= 0.71.0', '< 2.0.0') # Great HTTP Client
   spec.add_dependency('faraday-cookie_jar', '~> 0.0.6')
   spec.add_dependency('faraday', '~> 1.0') # The faraday gem is used for deploygate, hockey and testfairy actions.
   spec.add_dependency('faraday_middleware', '~> 1.0') # Same as faraday


### PR DESCRIPTION
## Summary

Widens fastlane's excon dependency ceiling from `< 1.0.0` to `< 2.0.0`, mirroring upstream [fastlane/fastlane#30085](https://github.com/fastlane/fastlane/pull/30085). One line in `fastlane.gemspec` plus the regenerated `Gemfile.lock` — no code changes.

## Problem

A published excon vulnerability cannot be patched in [untitledstartup/speckel](https://github.com/untitledstartup/speckel) while this fork caps excon below 1.0.

Speckel has an open Dependabot alert for [CVE-2026-54171](https://nvd.nist.gov/vuln/detail/CVE-2026-54171) / [GHSA-48rx-c7pg-q66r](https://github.com/advisories/GHSA-48rx-c7pg-q66r), MEDIUM severity: excon fails to redact additional sensitive headers when following redirects. The fix shipped in excon 1.5.0. Speckel currently resolves excon 0.112.0.

Speckel pins this fork directly in its `Gemfile`:

```ruby
gem 'fastlane', git: 'https://github.com/untitledstartup/fastlane.git', branch: 'brick/pem-login-fix', require: false
```

That pin makes this fork's ceiling the ceiling for speckel's entire bundle. Bundler names the constraint without ambiguity:

```
Because every version of fastlane depends on excon >= 0.71.0, < 1.0.0
  and Gemfile depends on fastlane >= 0,
  excon >= 0.71.0, < 1.0.0 is required.
```

Nothing else is blocking the upgrade behind fastlane. Swapping released fastlane 2.237.0 into speckel as an experiment lets it resolve cleanly to excon 1.6.0 and fog-core 2.6.0.

Re-pinning the fork to a newer upstream tag is not an available shortcut either. Upstream shipped this widening only in 2.237.0, and this fork branched from 2.211.0 with local changes on top.

## Solution

Apply upstream's change to the fork so consumers can resolve a patched excon.

**Constraint (`fastlane.gemspec`)** — the ceiling moves to the next major, exactly as upstream chose. This is a verbatim mirror of [fastlane/fastlane#30085](https://github.com/fastlane/fastlane/pull/30085); the upstream diff was fetched via `gh api repos/fastlane/fastlane/pulls/30085/files` and matched rather than a bound being picked independently.

```ruby
-  spec.add_dependency('excon', '>= 0.71.0', '< 1.0.0') # Great HTTP Client
+  spec.add_dependency('excon', '>= 0.71.0', '< 2.0.0') # Great HTTP Client
```

**Lockfile (`Gemfile.lock`)** — regenerated with `bundle lock --update=excon`, which mirrors the constraint into the `PATH` section, moves the resolved `excon` from 0.94.0 to 1.6.0, and picks up `logger (1.7.0)`, a new transitive runtime dependency of excon 1.x. There is no other churn in the file.

This is the same shape of change this fork has taken before — [untitledstartup/fastlane#15](https://github.com/untitledstartup/fastlane/pull/15) was a one-line `fastlane.gemspec` dependency bump plus a regenerated `Gemfile.lock`.

### excon API surface used by this fork

Every non-spec `Excon.` call site in the fork, checked against excon `main` (1.x) source:

| File | excon API used | Present in excon 1.x |
|---|---|---|
| `fastlane/lib/fastlane/actions/github_api.rb` | `Excon.defaults[:ssl_verify_peer]`, `Excon.defaults[:middlewares]`, `Excon::Middleware::RedirectFollower`, `Excon.new` | Yes |
| `fastlane/lib/fastlane/actions/xcode_server_get_assets.rb` | `Excon.defaults[:ssl_verify_peer]`, `Excon.get` | Yes |
| `fastlane_core/lib/fastlane_core/update_checker/changelog.rb` | `Excon.get`, `Excon.defaults[:middlewares]`, `Excon::Middleware::RedirectFollower` | Yes |
| `fastlane_core/lib/fastlane_core/update_checker/update_checker.rb` | `Excon.get` | Yes |
| `frameit/lib/frameit/frame_downloader.rb` | `Excon.get` | Yes |

**Caveat, stated plainly:** fastlane 2.211.0 — this fork's version — has never been CI'd against excon 1.x. Upstream only exercised the widened bound on 2.237.0. The call sites above are API-stable by source inspection, but that is the extent of the validation here; fastlane's own test suite was not run against excon 1.x for this change.

## Design Decisions

| Decision | Context |
|---|---|
| Ceiling set to `< 2.0.0`, not `~> 1.5` or an unbounded requirement | Matches upstream [fastlane/fastlane#30085](https://github.com/fastlane/fastlane/pull/30085) exactly. A tighter bound would diverge from upstream and create a second constraint to reconcile the next time this fork rebases; an unbounded one would let a future excon 2.x major in untested. |
| `required_ruby_version` left at `>= 2.6` | excon 1.x requires Ruby `>= 3.1`, which is above this fork's floor — but upstream is in the same position (2.237.0 declares `>= 3.0`) and shipped the widening regardless. The `>= 0.71.0` lower bound is retained, so a consumer on Ruby < 3.1 simply resolves an excon 0.x exactly as it does today. This widens the ceiling; it does not raise the floor. Speckel runs Ruby 3.4.7 and is unaffected either way. |

## Blast Radius

Anything that pins this fork and runs fastlane — in practice speckel's mobile build and release lanes. The affected surface is the handful of HTTP call sites in the table above: the `github_api` action, the `xcode_server_get_assets` action, the update checker, and frameit's frame downloader.

Consumers that do not re-resolve their lockfile see no change at all. The constraint only widens what a future `bundle update` may pick.

## Rollback Plan

Revert this PR via GitHub's Revert button. Consumers pinning the fork by branch pick the revert up on their next `bundle update`; consumers already resolved to excon 1.x can pin back with `bundle update excon --conservative` after the revert lands.

## Dependencies

No upstream dependency — this is self-contained.

Downstream and deliberately gated: speckel's `bundle update fastlane excon fog-core`, which is what actually closes Dependabot alert 594, depends on this merging first. No speckel PR has been opened yet.

## Test plan

**Verifiable by agent before merging**

- [x] `bundle lock --update=excon` resolves cleanly with the widened bound, picking excon 1.6.0
- [x] Reviewed the regenerated `Gemfile.lock` diff for unrelated churn — the only changes are the `PATH` constraint line, the excon version bump, and excon's new `logger` transitive dependency
- [x] Enumerated every non-spec `Excon.` call site in the fork and confirmed each API still exists in excon `main` (1.x)
- [x] Confirmed the gemspec delta matches upstream [fastlane/fastlane#30085](https://github.com/fastlane/fastlane/pull/30085) rather than an independently chosen bound

**Cannot be verified before merge**

- [ ] fastlane's own test suite against excon 1.x — upstream validated the widened bound on 2.237.0, and this fork is at 2.211.0, so no equivalent run exists for this code
- [ ] A speckel `bundle update fastlane excon fog-core` resolving against the merged fork — requires this branch to be merged into `brick/pem-login-fix` first, since speckel pins the branch
- [ ] Mobile build and release lanes exercising the `github_api` action and update checker under excon 1.x — requires the fastlane CI/release environment
